### PR TITLE
VSM-59 | View QIPs on the cards in canvas

### DIFF
--- a/components/canvas/VsmObjectFactory.tsx
+++ b/components/canvas/VsmObjectFactory.tsx
@@ -13,7 +13,7 @@ export function vsmObjectFactory(
   onPress: () => void,
   onHoverEnter: () => void,
   onHoverExit: () => void
-): PIXI.DisplayObject {
+): PIXI.Container {
   const { pkObjectType, name } = o.vsmObjectType;
   switch (pkObjectType) {
     case vsmObjectTypes.text:
@@ -27,6 +27,7 @@ export function vsmObjectFactory(
         onPress: () => onPress(),
         onHover: () => onHoverEnter(),
         onHoverExit: () => onHoverExit(),
+        tasks: o.tasks,
       });
     case vsmObjectTypes.choice:
       return Choice({
@@ -50,6 +51,7 @@ export function vsmObjectFactory(
         onPress: () => onPress(),
         onHover: () => onHoverEnter(),
         onHoverExit: () => onHoverExit(),
+        tasks: o.tasks,
       });
     case vsmObjectTypes.mainActivity:
       return MainActivity({
@@ -63,6 +65,7 @@ export function vsmObjectFactory(
         text: o.name,
         role: o.role || "Role?",
         time: formatDuration(o.time, o.timeDefinition),
+        tasks: o.tasks,
         onPress: () => onPress(),
         onHover: () => onHoverEnter(),
         onHoverExit: () => onHoverExit(),
@@ -72,7 +75,8 @@ export function vsmObjectFactory(
         formatDuration(o.time, o.timeDefinition),
         () => onPress(),
         () => onHoverEnter(),
-        () => onHoverExit()
+        () => onHoverExit(),
+        o.tasks
       );
     default:
       return GenericPostit({

--- a/components/canvas/entities/Choice.tsx
+++ b/components/canvas/entities/Choice.tsx
@@ -17,7 +17,8 @@ export default function Choice({
   onHover,
   onHoverExit,
 }: ChoiceProps) {
-  const width = 126;
+  const defaultCardWidth = 126;
+  const width = defaultCardWidth;
   const color = 0xffd800;
 
   // Create a rectangle and rotate it 45 degrees
@@ -30,6 +31,10 @@ export default function Choice({
   rectangle.pivot.y = rectangle.height / 2;
 
   rectangle.angle = 45;
+
+  const defaultCardHeight = 136;
+  rectangle.x = defaultCardWidth / 2;
+  rectangle.y = defaultCardHeight / 2;
 
   const contentText = new PIXI.Text(formatCanvasText(content || "Choice", 45), {
     fill: 0x3d3d3d,
@@ -48,11 +53,12 @@ export default function Choice({
   contentText.anchor.set(0.5, 0.5);
   contentText.resolution = 4;
 
+  contentText.x = defaultCardWidth / 2;
+  contentText.y = defaultCardHeight / 2;
+
   const container = new PIXI.Container();
 
   container.addChild(rectangle, contentText);
-  container.x = container.width / 2;
-  container.y = container.height / 2;
 
   if (onHover) container.on(pointerEvents.pointerover, () => onHover());
   if (onHoverExit) container.on(pointerEvents.pointerout, () => onHoverExit());

--- a/components/canvas/entities/CreateGrid.tsx
+++ b/components/canvas/entities/CreateGrid.tsx
@@ -1,0 +1,42 @@
+import * as PIXI from "pixi.js";
+
+/**
+ * Return a grid of the PIXI.Container items
+ * @param items
+ * @param breakAt
+ * @param spaceBetween
+ */
+export function createGrid(
+  items: PIXI.Container[],
+  breakAt = 4,
+  spaceBetween = 4
+): PIXI.Container {
+  const container = new PIXI.Container();
+  let lastItem;
+  items?.forEach((item: PIXI.DisplayObject, i) => {
+    // GRID LAYOUT. Default breaking at 4 items in height.
+
+    const topItem = i !== 0 && i % breakAt === 0;
+    const firstItem = !lastItem;
+
+    if (firstItem) {
+      // Put it top left
+      item.y = spaceBetween; // Row
+      item.x = spaceBetween; // Column
+    } else {
+      if (topItem) {
+        // We have a new column (x)
+        // Put it on the top and move it right so it doesn't go over the last item
+        item.y = spaceBetween;
+        item.x = lastItem.x + lastItem.width + spaceBetween;
+      } else {
+        // Move it down a row (y). Keep the column (x) placement
+        item.y = lastItem.y + lastItem.height + spaceBetween;
+        item.x = lastItem.x;
+      }
+    }
+    container.addChild(item);
+    lastItem = item;
+  });
+  return container;
+}

--- a/components/canvas/entities/CreateSideContainer.tsx
+++ b/components/canvas/entities/CreateSideContainer.tsx
@@ -1,0 +1,38 @@
+import * as PIXI from "pixi.js";
+import { taskSorter } from "../../SideBarContent";
+import { vsmTaskTypes } from "../../../types/vsmTaskTypes";
+import { TextCircle } from "./TextCircle";
+import { createGrid } from "./CreateGrid";
+import { taskObject } from "../../../interfaces/taskObject";
+
+export function createSideContainer(
+  tasks: taskObject[],
+  breakAt: number,
+  height = 136
+): PIXI.Container {
+  const sideContainer = new PIXI.Container();
+  if (tasks?.length > 0) {
+    const newTasks = tasks.sort(taskSorter()).map((t) => {
+      switch (t?.fkTaskType) {
+        case vsmTaskTypes.problem:
+          return TextCircle(`P${t.vsmTaskID}`, 0xff0000);
+        case vsmTaskTypes.question:
+          return TextCircle(`Q${t.vsmTaskID}`, 0x007079);
+        case vsmTaskTypes.idea:
+          return TextCircle(`I${t.vsmTaskID}`, 0xff6670);
+        default:
+          return TextCircle(`${t}`);
+      }
+    });
+
+    const taskContainer = createGrid(newTasks, breakAt);
+    const rectangleSide = new PIXI.Graphics();
+    rectangleSide.beginFill(0xededed);
+    rectangleSide.drawRect(0, 0, taskContainer.width + 16, height);
+    rectangleSide.endFill();
+    sideContainer.addChild(rectangleSide, taskContainer);
+    taskContainer.x = 4;
+    taskContainer.y = 2;
+  }
+  return sideContainer;
+}

--- a/components/canvas/entities/SubActivity.tsx
+++ b/components/canvas/entities/SubActivity.tsx
@@ -1,9 +1,10 @@
 import * as PIXI from "pixi.js";
 import { Graphics } from "pixi.js";
 import { formatCanvasText } from "../FormatCanvasText";
-import { ProblemCircle } from "./ProblemCircle";
 import { clickHandler } from "./ClickHandler";
 import { pointerEvents } from "../../VSMCanvas";
+import { taskObject } from "../../../interfaces/taskObject";
+import { createSideContainer } from "./CreateSideContainer";
 
 interface SubActivityProps {
   text?: string;
@@ -13,6 +14,7 @@ interface SubActivityProps {
   onHover?: () => void;
   onHoverExit?: () => void;
   disableSideContainer?: boolean;
+  tasks?: taskObject[];
 }
 
 export default function SubActivity({
@@ -22,7 +24,8 @@ export default function SubActivity({
   onPress,
   onHover,
   onHoverExit,
-  disableSideContainer = true,
+  tasks,
+  disableSideContainer = false,
 }: SubActivityProps): PIXI.Container {
   const header = "Sub- activity";
   const width = 126;
@@ -40,30 +43,8 @@ export default function SubActivity({
 
   const rectangle = createBaseContainer();
 
-  function createSideContainer() {
-    // todo: SideContainer stuff. I started it off for you with some demo content ;)
-    const rectangleSide = new Graphics();
-    rectangleSide.beginFill(0xededed);
-    rectangleSide.drawRect(0, 0, 71, 136);
-    rectangleSide.endFill();
-
-    const c1 = ProblemCircle("P1");
-    c1.x = rectangleSide.x + 4;
-    c1.y = rectangleSide.y + 4;
-    const c2 = ProblemCircle("P2");
-    c2.x = c1.x;
-    c2.y = c1.y + c1.height + 4;
-    const c3 = ProblemCircle("P3");
-    c3.x = c2.x;
-    c3.y = c2.y + c2.height + 4;
-
-    const sideContainer = new PIXI.Container();
-    sideContainer.x = rectangle.width;
-    sideContainer.addChild(rectangleSide, c1, c2, c3);
-    return sideContainer;
-  }
-
-  const sideContainer = createSideContainer();
+  const sideContainer = createSideContainer(tasks);
+  sideContainer.x = rectangle.width;
 
   const defaultStyle = {
     fill: 0x3d3d3d,

--- a/components/canvas/entities/TextCircle.tsx
+++ b/components/canvas/entities/TextCircle.tsx
@@ -1,9 +1,9 @@
 import * as PIXI from "pixi.js";
 import { Graphics } from "pixi.js";
 
-export function ProblemCircle(text = "P?") {
+export function TextCircle(text = "?", color = 0x000000): PIXI.Container {
   const circle = new Graphics();
-  circle.beginFill(0xff0000);
+  circle.beginFill(color);
   circle.drawCircle(0, 0, 13);
   circle.endFill();
   circle.pivot.set(-circle.width / 2, -circle.height / 2);
@@ -20,8 +20,10 @@ export function ProblemCircle(text = "P?") {
     fontColor: "white",
   });
   circleText.resolution = 4;
-  circleText.x = circle.width / 4;
-  circleText.y = circle.height / 4;
+  // Center text
+  circleText.anchor.set(0.5);
+  circleText.y = circle.height / 2;
+  circleText.x = circle.width / 2;
 
   const circleContainer = new PIXI.Container();
   circleContainer.addChild(circle, circleText);

--- a/components/canvas/entities/Waiting.tsx
+++ b/components/canvas/entities/Waiting.tsx
@@ -4,12 +4,15 @@ import { formatCanvasText } from "../FormatCanvasText";
 import { icons } from "../../../assets/icons";
 import { clickHandler } from "./ClickHandler";
 import { pointerEvents } from "../../VSMCanvas";
+import { createSideContainer } from "./CreateSideContainer";
+import { taskObject } from "../../../interfaces/taskObject";
 
 export default function Waiting(
   time = "unknown",
   onPress?: () => void,
   onHover?: () => void,
-  onHoverExit?: () => void
+  onHoverExit?: () => void,
+  tasks?: taskObject[]
 ): PIXI.Container {
   const header = "Waiting";
   const width = 126;
@@ -19,6 +22,9 @@ export default function Waiting(
   const background = new Graphics();
   background.beginFill(color);
   background.drawRect(0, 0, width, height);
+
+  const sideContainer = createSideContainer(tasks, 2, background.height);
+  sideContainer.x = background.width;
 
   const paddingLeft = 6;
   const paddingTop = 10;
@@ -56,12 +62,13 @@ export default function Waiting(
 
   const mask = new PIXI.Graphics();
   mask.beginFill(color);
-  mask.drawRoundedRect(0, 0, width, height, 6);
+  mask.drawRoundedRect(0, 0, width + sideContainer.width, height, 6);
   background.mask = mask;
+  sideContainer.mask = mask;
   textTime.mask = mask;
 
   const container = new PIXI.Container();
-  container.addChild(mask, background, text, iconTime, textTime);
+  container.addChild(mask, background, text, iconTime, textTime, sideContainer);
 
   const paddingContainer = new Graphics();
   paddingContainer.drawRect(0, 0, 126, 136);

--- a/interfaces/VsmObject.tsx
+++ b/interfaces/VsmObject.tsx
@@ -2,21 +2,22 @@ import { vsmObjectTypes } from "../types/vsmObjectTypes";
 import { vsmTaskTypes } from "../types/vsmTaskTypes";
 
 export interface vsmObject {
-  vsmObjectID: number;
+  vsmObjectID?: number;
   vsmProjectID?: number;
-  bigBrother?: number; //Todo: figure out with Peder how this will work
+  bigBrother?: number; //Todo: figure out with Peder how this will work. I think it should be leftObjectId
+  position?: number;
   parent?: number;
-  name: string;
-  fkObjectType?: number;
-  time: number;
-  timeDefinition: string;
-  role: string;
+  name?: string;
+  fkObjectType?: vsmObjectTypes;
+  time?: number;
+  timeDefinition?: string;
+  role?: string;
   childObjects?: Array<vsmObject>;
   vsmObjectType?: {
     pkObjectType: vsmObjectTypes;
-    name: string;
-    description: null;
-    hidden: boolean;
+    name?: string;
+    description?: null;
+    hidden?: boolean;
   };
   tasks?: [];
   created?: {

--- a/interfaces/taskObject.tsx
+++ b/interfaces/taskObject.tsx
@@ -1,0 +1,20 @@
+import { vsmTaskTypes } from "../types/vsmTaskTypes";
+import { vsmObject } from "./VsmObject";
+
+export interface taskObject {
+  vsmTaskID?: number; // On Post -> Set to null if new task
+  draft?: boolean; // Only used locally. Remove before sending to api
+  fkTaskType: vsmTaskTypes;
+  taskType?: { vsmTaskTypeID: vsmTaskTypes; name: string; description: string };
+  name: string;
+  description?: string;
+  solved?: boolean;
+  solvedDate?: string;
+  fkProject: number;
+  objects?: [
+    {
+      fkObject: vsmObject;
+    }
+  ];
+  changeLogs?: unknown[];
+}

--- a/types/vsmTaskTypes.tsx
+++ b/types/vsmTaskTypes.tsx
@@ -1,3 +1,6 @@
 export enum vsmTaskTypes {
- someTaskType=1
+  problem = 1,
+  question,
+  idea,
+  unknown, // <- Not supported by api. Used in sorting and as a default type.
 }


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/3164065/111642212-2fe65800-87fe-11eb-82ce-755b7dd2c465.png)

All cards except Choice & MainActivity should support tasks (aka. labels or QIPs)
- [x] SubActivity.tsx
- [x] Waiting.tsx
- [x] GenericPostit.tsx (Supplier, Input, Output, Customer)
https://equinor-sds-si.atlassian.net/browse/VSM-59

<img width="1050" alt="image" src="https://user-images.githubusercontent.com/3164065/111790985-122ef680-88c3-11eb-94f4-940c12a284b7.png">
