### PR TITLE
Fix layout width when not enough vsms

### DIFF
--- a/styles/common.module.scss
+++ b/styles/common.module.scss
@@ -17,6 +17,7 @@
 
   animation-name: fade-in;
   animation-duration: 0.5s;
+  width: 100%;
 }
 
 .appear {
@@ -27,6 +28,6 @@
 @keyframes fade-in {
   from {
     opacity: 0;
-    transform: translateY(10px)
+    transform: translateY(10px);
   }
 }


### PR DESCRIPTION
Displayed strangely when less than a screen-length of vsms. Now it uses the whole screen no matter what.
