### PR TITLE
:truck: Move assets into assetFactory

### DIFF
--- a/components/canvas/Canvas.tsx
+++ b/components/canvas/Canvas.tsx
@@ -18,6 +18,7 @@ import {
   getOnChangeTimeDefinition,
 } from "./utils/vsmObjectChangeHandlers";
 import { getUserCanEdit } from "../GetUserCanEdit";
+import { assets } from "./utils/AssetFactory";
 
 export default function Canvas(): JSX.Element {
   const ref = useRef();
@@ -35,34 +36,7 @@ export default function Canvas(): JSX.Element {
   // "Constructor"
   useEffect(() => {
     initCanvas(ref);
-    const cleanupAssets = loadAssets(
-      {
-        choice: "/Choice.png",
-        genericTaskSection: "/genericTaskSection.png",
-        genericTaskSectionEdge: "/genericTaskSectionEdge.png",
-        waitingTaskSection: "/waitingTaskSection.png",
-        waitingTaskSectionEdge: "/waitingTaskSectionEdge.png",
-        generic: "/Postit/Grey.png",
-        genericStraight: "/Postit/Green/Straight.png",
-        ideaCircle: "/Idea/small/primary.png",
-        unknownCircle: "/Unknown/small/primary.png",
-        mainActivity: "/Postit/Blue.png",
-        mainActivityStraight: "/Postit/Blue/Straight.png",
-        problemCircle: "/Problem/small/primary.png",
-        questionCircle: "/Question/small/primary.png",
-        subActivity: "/Postit/Yellow.png",
-        subActivityStraight: "/Postit/Yellow/Straight.png",
-        waiting: "/Postit/Orange/Icon.png",
-        waitingStraight: "/Postit/Orange/Icon/Straight.png",
-        errorCard: "/ErrorPostit.png",
-        toolbox: "/Toolbox.png",
-        toolboxMainActivity: "/ToolboxMainActivity.png",
-        toolboxSubActivity: "/ToolboxSubActivity.png",
-        toolboxWaiting: "/ToolboxWaiting.png",
-        toolboxChoice: "/ToolboxChoice.png",
-      },
-      () => setAssetsAreLoaded(true)
-    );
+    const cleanupAssets = loadAssets(assets, () => setAssetsAreLoaded(true));
     return () => {
       cleanupAssets();
       getApp().stage.removeChildren();

--- a/components/canvas/utils/AssetFactory.ts
+++ b/components/canvas/utils/AssetFactory.ts
@@ -19,6 +19,32 @@ import { createWaitingAsset } from "./assetGenerators/CreateWaitingAsset";
 import { createChoiceAsset } from "./assetGenerators/CreateChoiceAsset";
 import { nothingHasChangedOfImportanceForRenderingThisCard } from "./NothingHasChangedOfImportanceForRenderingThisCard";
 
+export const assets = {
+  choice: "/Choice.png",
+  genericTaskSection: "/genericTaskSection.png",
+  genericTaskSectionEdge: "/genericTaskSectionEdge.png",
+  waitingTaskSection: "/waitingTaskSection.png",
+  waitingTaskSectionEdge: "/waitingTaskSectionEdge.png",
+  generic: "/Postit/Grey.png",
+  genericStraight: "/Postit/Green/Straight.png",
+  ideaCircle: "/Idea/small/primary.png",
+  unknownCircle: "/Unknown/small/primary.png",
+  mainActivity: "/Postit/Blue.png",
+  mainActivityStraight: "/Postit/Blue/Straight.png",
+  problemCircle: "/Problem/small/primary.png",
+  questionCircle: "/Question/small/primary.png",
+  subActivity: "/Postit/Yellow.png",
+  subActivityStraight: "/Postit/Yellow/Straight.png",
+  waiting: "/Postit/Orange/Icon.png",
+  waitingStraight: "/Postit/Orange/Icon/Straight.png",
+  errorCard: "/ErrorPostit.png",
+  toolbox: "/Toolbox.png",
+  toolboxMainActivity: "/ToolboxMainActivity.png",
+  toolboxSubActivity: "/ToolboxSubActivity.png",
+  toolboxWaiting: "/ToolboxWaiting.png",
+  toolboxChoice: "/ToolboxChoice.png",
+};
+
 let sprites:
   | { sprite: PIXI.Container; data: vsmObject }
   | Record<string, unknown> = {};


### PR DESCRIPTION
Makes sense to keep it where they are used. Even though they are loaded in the view. Maybe we could refactor that so that the assetfactory trigger the loading as well? Something to think about for later.
