### PR TITLE
Role should be only one line

### DIFF
--- a/components/canvas/utils/assetGenerators/GetRoleText.ts
+++ b/components/canvas/utils/assetGenerators/GetRoleText.ts
@@ -1,9 +1,22 @@
 import * as PIXI from "pixi.js";
+import { TextStyle } from "pixi.js";
 import { formatCanvasText } from "../FormatCanvasText";
-import { defaultTextStyle } from "../AssetFactory";
 import { vsmObject } from "../../../../interfaces/VsmObject";
+
+const roleTextStyle = {
+  fill: 0x3d3d3d,
+  fontFamily: "Equinor",
+  fontWeight: "500",
+  fontSize: 12,
+  lineHeight: 16,
+  letterSpacing: 0.2,
+  wordWrapWidth: 100,
+  wordWrap: false,
+  breakWords: false,
+  trim: true,
+} as TextStyle;
 
 export function getRoleText(vsmObject: vsmObject): PIXI.Text {
   const { role } = vsmObject;
-  return new PIXI.Text(formatCanvasText(role ?? "", 16), defaultTextStyle);
+  return new PIXI.Text(formatCanvasText(role ?? "", 16), roleTextStyle);
 }


### PR DESCRIPTION
Fix #90 

Bug with ID 71:In sub-activities; when the role is above a certain length it is divided over two lines. The second line interrupts with the time input on the cards. An example from project 139 is the role “Operation engineer”. The word “Operation” sits in the first row, while the second row has “engine” in it, on top of the time.

https://equinor-sds-si.atlassian.net/browse/VSM-163