### PR TITLE
Display newlines in cards

### DIFF
--- a/components/canvas/utils/FormatCanvasText.ts
+++ b/components/canvas/utils/FormatCanvasText.ts
@@ -1,8 +1,13 @@
-export function formatCanvasText(text: string | null, maxLength = 100): string {
+export function formatCanvasText(
+  text: string | null,
+  maxLength = 100,
+  removeNewLines = false
+): string {
   if (!text) return "";
   let formattedText = text;
   if (text.length > maxLength) {
     formattedText = `${text?.slice(0, maxLength)}...`;
   }
-  return formattedText.replace(/(\r\n|\n|\r)/gm, " ");
+  if (removeNewLines) return formattedText.replace(/(\r\n|\n|\r)/gm, " ");
+  return formattedText;
 }

--- a/components/canvas/utils/assetGenerators/CreateChoiceAsset.ts
+++ b/components/canvas/utils/assetGenerators/CreateChoiceAsset.ts
@@ -31,5 +31,11 @@ export function createChoiceAsset(
   contentText.x = 126 / 2;
   contentText.y = 126 / 2;
   wrapper.addChild(new PIXI.Sprite(choice.texture), contentText);
+
+  const mask = new PIXI.Graphics();
+  mask.drawRect(0, 0, 126, 126);
+  contentText.mask = mask;
+  wrapper.addChild(mask);
+
   return wrapper;
 }

--- a/components/canvas/utils/assetGenerators/CreateGenericCardAsset.ts
+++ b/components/canvas/utils/assetGenerators/CreateGenericCardAsset.ts
@@ -45,5 +45,10 @@ export function createGenericCardAsset(
   textSprite.y = 21;
   wrapper.addChild(textSprite);
 
+  const mask = new PIXI.Graphics();
+  mask.drawRect(0, 0, 126, 134);
+  textSprite.mask = mask;
+  wrapper.addChild(mask);
+
   return wrapper;
 }

--- a/components/canvas/utils/assetGenerators/CreateMainActivityAsset.ts
+++ b/components/canvas/utils/assetGenerators/CreateMainActivityAsset.ts
@@ -40,5 +40,11 @@ export function createMainActivityAsset(
   );
 
   wrapper.addChild(textSprite);
+
+  const mask = new PIXI.Graphics();
+  mask.drawRect(0, 0, 126, 134);
+  textSprite.mask = mask;
+  wrapper.addChild(mask);
+
   return wrapper;
 }

--- a/components/canvas/utils/assetGenerators/CreateSubActivityAsset.ts
+++ b/components/canvas/utils/assetGenerators/CreateSubActivityAsset.ts
@@ -49,5 +49,10 @@ export function createSubActivityAsset(
   );
   if (taskSection) wrapper.addChild(taskSection);
 
+  const mask = new PIXI.Graphics();
+  mask.drawRect(0, 0, 126, 88);
+  textSprite.mask = mask;
+  wrapper.addChild(mask);
+
   return wrapper;
 }

--- a/components/canvas/utils/assetGenerators/GetRoleText.ts
+++ b/components/canvas/utils/assetGenerators/GetRoleText.ts
@@ -18,5 +18,5 @@ const roleTextStyle = {
 
 export function getRoleText(vsmObject: vsmObject): PIXI.Text {
   const { role } = vsmObject;
-  return new PIXI.Text(formatCanvasText(role ?? "", 16), roleTextStyle);
+  return new PIXI.Text(formatCanvasText(role ?? "", 16, true), roleTextStyle);
 }

--- a/components/canvas/utils/assetGenerators/GetTimeText.ts
+++ b/components/canvas/utils/assetGenerators/GetTimeText.ts
@@ -6,5 +6,5 @@ import { vsmObject } from "../../../../interfaces/VsmObject";
 
 export function getTimeText(vsmObject: vsmObject): PIXI.Text {
   const time = formatDuration(vsmObject.time, vsmObject.timeDefinition);
-  return new PIXI.Text(formatCanvasText(time, 12), defaultTextStyle);
+  return new PIXI.Text(formatCanvasText(time, 12, true), defaultTextStyle);
 }


### PR DESCRIPTION
Add support for multiple lines in the cards on the canvas.
Solved by adding a mask on the text. This might have some performance impact...

> Feedback ID32: In all post-it boxes, the text is visualized as one long paragraph. I would like to see the card with the same layout as my original input, including returns and spaces between paragraphs.

fixes #103 vsm-169
