### PR TITLE
Hover tooltip to read the whole description when adding existing QIP

### DIFF
--- a/components/ExistingTaskSection.tsx
+++ b/components/ExistingTaskSection.tsx
@@ -77,7 +77,7 @@ export function ExistingTaskSection(props: {
       <div>
         <ul className={styles.taskList}>
           {existingTasks?.map((t: taskObject) => (
-            <li key={t.vsmTaskID}>
+            <li key={t.vsmTaskID} title={t.description}>
               <Checkbox
                 defaultChecked={tasks.some(
                   (task) => task?.vsmTaskID === t?.vsmTaskID


### PR DESCRIPTION
fixes #105 vsm-170


Using a hover instead of using multiple lines in the list 
![image](https://user-images.githubusercontent.com/3164065/128490097-b6e1d0b5-c229-4969-bebf-e22242d7e3ae.png)

If we put it on multiple lines, the list might look bad. Would like to talk with our designer before doing any changes there.