### PR TITLE
fix(durationcomponent): fix erros when updating time on a card

### DIFF
--- a/components/DurationComponent.tsx
+++ b/components/DurationComponent.tsx
@@ -5,23 +5,34 @@ import {
   getTimeDefinitionValue,
   getTimeDefinitionValues,
 } from "../types/timeDefinitions";
-import React from "react";
+import React, { useEffect, useState } from "react";
 
 export function DurationComponent(props: {
   selectedObject: vsmObject;
-  onChangeTime: (event: { target: { value: string } }) => void;
-  onChangeTimeDefinition: (timeDefinition: string) => void;
+  onChangeTime: (e: { time: number; unit: string }) => void;
   disabled: boolean;
 }): JSX.Element {
+  const [time, setTime] = useState(props.selectedObject.time);
+  const [unit, setUnit] = useState(props.selectedObject.timeDefinition);
+
+  useEffect(() => {
+    props.onChangeTime({ time: time, unit });
+  }, [time, unit]);
+
+  useEffect(() => {
+    setTime(props.selectedObject.time);
+    setUnit(props.selectedObject.timeDefinition);
+  }, [props.selectedObject]);
+
   return (
     <div style={{ display: "flex" }}>
       <TextField
         disabled={props.disabled}
         label={"Duration"}
         type={"number"}
-        defaultValue={props.selectedObject.time?.toString()}
         id={"vsmObjectTime"}
-        onChange={props.onChangeTime}
+        value={`${time}`}
+        onChange={(event) => setTime(parseFloat(event.target.value))}
       />
       <div style={{ padding: 8 }} />
       <SingleSelect
@@ -29,11 +40,9 @@ export function DurationComponent(props: {
         items={getTimeDefinitionValues()}
         handleSelectedItemChange={(i) => {
           const apiValue = getTimeDefinitionValue(i.selectedItem);
-          props.onChangeTimeDefinition(apiValue);
+          setUnit(apiValue);
         }}
-        initialSelectedItem={getTimeDefinitionDisplayName(
-          props.selectedObject.timeDefinition
-        )}
+        value={getTimeDefinitionDisplayName(unit)}
         label="Unit"
       />
     </div>

--- a/components/SideBarBody.tsx
+++ b/components/SideBarBody.tsx
@@ -9,8 +9,7 @@ export function SideBarBody(props: {
   selectedObject: vsmObject;
   onChangeName: (event: { target: { value: string } }) => void;
   onChangeRole: (event: { target: { value: string } }) => void;
-  onChangeTime: (event: { target: { value: string } }) => void;
-  onChangeTimeDefinition: (timeDefinition: string) => void;
+  onChangeTime: (e: { time: number; unit: string }) => void;
   setShowNewTaskSection: (boolean) => void;
   canEdit: boolean;
 }): JSX.Element {
@@ -156,7 +155,6 @@ export function SideBarBody(props: {
             <DurationComponent
               disabled={!props.canEdit}
               onChangeTime={props.onChangeTime}
-              onChangeTimeDefinition={props.onChangeTimeDefinition}
               selectedObject={selectedObject}
             />
           </div>

--- a/components/SideBarContent.tsx
+++ b/components/SideBarContent.tsx
@@ -52,9 +52,6 @@ export function SideBarContent(props: {
       role?: string;
       time?: number;
       timeDefinition?: string;
-      //Todo: BUG in API? Patching timeDefinition sets time to 0...
-      // Not a bug, but a "feature": Changing unit does a conversion of the current time to the new format.
-      // Ref: https://equinor-sds-si.atlassian.net/browse/VSM-160
     }
   ) {
     debounce(
@@ -137,10 +134,7 @@ export function SideBarContent(props: {
           patchCard(selectedObject, { role: e.target.value })
         }
         onChangeTime={(e) =>
-          patchCard(selectedObject, { time: parseFloat(e.target.value) })
-        }
-        onChangeTimeDefinition={(e) =>
-          patchCard(selectedObject, { timeDefinition: e })
+          patchCard(selectedObject, { time: e.time, timeDefinition: e.unit })
         }
         setShowNewTaskSection={setShowNewTaskSection}
         canEdit={props.canEdit}

--- a/pages/projects/[id]/qips/[taskId].tsx
+++ b/pages/projects/[id]/qips/[taskId].tsx
@@ -175,7 +175,6 @@ export default function Category(): JSX.Element {
                     onChangeName={(e) => console.log(e)}
                     onChangeRole={(e) => console.log(e)}
                     onChangeTime={(e) => console.log(e)}
-                    onChangeTimeDefinition={(e) => console.log(e)}
                     setShowNewTaskSection={(e) => console.log(e)}
                     canEdit={false}
                   />


### PR DESCRIPTION
There was a problem where the time was not saved when adding the unit first. Issue was some async calls to api overwriting each others... Fixed by always sending time and unit together.

fix #111
