### PR TITLE
fix(duration): do not send request when no change

### DIFF
--- a/components/DurationComponent.tsx
+++ b/components/DurationComponent.tsx
@@ -16,10 +16,6 @@ export function DurationComponent(props: {
   const [unit, setUnit] = useState(props.selectedObject.timeDefinition);
 
   useEffect(() => {
-    props.onChangeTime({ time: time, unit });
-  }, [time, unit]);
-
-  useEffect(() => {
     setTime(props.selectedObject.time);
     setUnit(props.selectedObject.timeDefinition);
   }, [props.selectedObject]);
@@ -32,7 +28,13 @@ export function DurationComponent(props: {
         type={"number"}
         id={"vsmObjectTime"}
         value={`${time}`}
-        onChange={(event) => setTime(parseFloat(event.target.value))}
+        onChange={(event) => {
+          setTime(parseFloat(event.target.value));
+          props.onChangeTime({
+            time: parseFloat(event.target.value),
+            unit: unit,
+          });
+        }}
       />
       <div style={{ padding: 8 }} />
       <SingleSelect
@@ -41,6 +43,7 @@ export function DurationComponent(props: {
         handleSelectedItemChange={(i) => {
           const apiValue = getTimeDefinitionValue(i.selectedItem);
           setUnit(apiValue);
+          props.onChangeTime({ time: time, unit: apiValue });
         }}
         value={getTimeDefinitionDisplayName(unit)}
         label="Unit"


### PR DESCRIPTION
We got a bug where a request to update the time is sent every time the DurationComponent is loaded.
Expected: Only send patch-update when user makes a change.

fix #139 improve #111
