### PR TITLE
PO requested changes

### DIFF
--- a/interfaces/VsmProject.tsx
+++ b/interfaces/VsmProject.tsx
@@ -24,4 +24,5 @@ export interface vsmProject {
   };
   objects: Array<vsmObject>;
   userAccesses: Array<userAccess>;
+  duplicateOf?: string;
 }

--- a/pages/projects/[id]/duplicate.tsx
+++ b/pages/projects/[id]/duplicate.tsx
@@ -31,7 +31,8 @@ export default function DuplicatePage() {
         project,
         `${!!project.name ? project.name : "Untitled VSM"} (Duplicate of ${
           project.vsmProjectID
-        })`
+        })`,
+        `${project.vsmProjectID}`
       );
       if (json) {
         setStatusMessage("Creating new project");

--- a/pages/projects/[id]/duplicate.tsx
+++ b/pages/projects/[id]/duplicate.tsx
@@ -29,7 +29,7 @@ export default function DuplicatePage() {
       setStatusMessage("Preparing project");
       const json = getProjectAsCleanJsonWithoutQIPs(
         project,
-        `Duplicate of ${!!project.name ? project.name : "Untitled VSM"} (${
+        `${!!project.name ? project.name : "Untitled VSM"} (Duplicate of ${
           project.vsmProjectID
         })`
       );

--- a/utils/DownloadJSON.ts
+++ b/utils/DownloadJSON.ts
@@ -4,10 +4,12 @@ import { stripGarbage } from "./StripGarbage";
 
 export function getProjectAsCleanJsonWithoutQIPs(
   project: vsmProject,
-  projectName?: string
+  projectName?: string,
+  duplicateOf?: string
 ) {
   return {
     name: projectName || project.name,
+    duplicateOf,
     objects: [
       {
         parent: 0,


### PR DESCRIPTION
PO wants a small change of the title when creating new project based on another one. 
> The title on a duplicate would be better if it was "Title (Duplicate of xx)" instead of "Duplicate of Title (xx)"

Fix #117

Add `duplicateOf` field to new project request when the new project is a duplicate.
Field `duplicateOf` contains a string of the `vsmProjectId` that a new project is duped from

fix #147