### PR TITLE
fix(service-message): Hide the service-message-banner when there is no active message.

### DIFF
--- a/components/ServiceMessageBanner.tsx
+++ b/components/ServiceMessageBanner.tsx
@@ -15,6 +15,7 @@ export const ServiceMessageBanner = () => {
   );
 
   if (isLoading || error) return null;
+  if (data && !data.status) return null; // https://github.com/equinor/MAD-VSM-WEB/issues/259#issue-1034675684
 
   return (
     <>


### PR DESCRIPTION
# Align logic with how MAD-Common v1 is set up to work
Version 1 of the [MAD-Common API](https://mad-api-dev.azurewebsites.net/swagger/index.html) returns an object even if there is no service-message currently active, which makes the service-banner show without any content.
![image](https://user-images.githubusercontent.com/3164065/138638824-b8614431-1bca-41ca-94f1-f59365a27bb0.png)

The status-key-value should reflect if it should be shown or not.
**API-Endpoint:** https://api.statoil.com/app/mad/api/v1/ServiceMessage/Flyt
## Example response when service-message is inactive.
```json5
{
  "status": false,
  "serviceName": null,
  "alertName": null,
  "message": null,
  "urlString": null,
  "fromDate": null,
  "toDate": null
}
```

- [x] **To-do:** Add check on the status.

## How to test:
Service-message should work as expected in accordance with the [Mad-Common-API.](https://mad-api-dev.azurewebsites.net/swagger/index.html)
Try to add a new message, update it and remove it by setting the status to false.

fix #259
