### PR TITLE
fix: url-encode the search query

### DIFF
--- a/pages/processes/favourite.tsx
+++ b/pages/processes/favourite.tsx
@@ -1,5 +1,4 @@
 import React, { useState } from "react";
-import commonStyles from "../../styles/common.module.scss";
 import styles from "./FrontPage.module.scss";
 import Head from "next/head";
 import { Layouts } from "../../layouts/LayoutWrapper";
@@ -26,8 +25,8 @@ export default function FavoriteProcesses(): JSX.Element {
         page,
         items: itemsPerPage,
         onlyFavorites: true,
-        q: searchQuery || "",
-        orderBy,
+        q: searchQuery ? `${searchQuery}` : "",
+        orderBy: orderBy && `${orderBy}`,
       })
   );
 

--- a/pages/processes/index.tsx
+++ b/pages/processes/index.tsx
@@ -23,8 +23,8 @@ export default function AllProcesses(): JSX.Element {
     getProjects({
       page,
       items: itemsPerPage,
-      q: searchQuery || "",
-      orderBy,
+      q: searchQuery ? `${searchQuery}` : "",
+      orderBy: orderBy && `${orderBy}`,
     })
   );
 

--- a/pages/processes/mine.tsx
+++ b/pages/processes/mine.tsx
@@ -32,8 +32,8 @@ export default function MyProcesses(): JSX.Element {
         page,
         user: userNameFilter,
         items: itemsPerPage,
-        q: searchQuery || "",
-        orderBy,
+        q: searchQuery ? `${searchQuery}` : "",
+        orderBy: orderBy && `${orderBy}`,
       })
   );
 

--- a/services/projectApi.ts
+++ b/services/projectApi.ts
@@ -7,9 +7,9 @@ import { createUrlParams } from "../utils/createUrlParams";
 const baseUrl = "/api/v1.0";
 //Project aka. VSM aka. Flyt or Flow
 export const getProjects = (filter?: {
-  q?: string | string[];
-  user?: string | string[];
-  orderBy?: string | string[];
+  q?: string;
+  user?: string;
+  orderBy?: string;
   page?: number;
   items?: number;
   onlyFavorites?: boolean;

--- a/utils/createUrlParams.ts
+++ b/utils/createUrlParams.ts
@@ -3,13 +3,21 @@
  * @param params
  */
 export function createUrlParams(params: {
-  [x: string]: string | string[] | number | boolean;
+  [x: string]: string | number | boolean;
 }): string {
   if (!params) return "";
+  let first = true;
   return Object.keys(params)
-    .map((key, index) => {
-      const prefix = index === 0 ? `?` : `&`;
-      return `${prefix}${key}=${params[key]}`;
+    .map((key) => {
+      // Do not add the key-value-pair if the value is empty
+      if (!params[key]) return "";
+
+      // If this is the first key-value-pair added, prefix with "?".
+      const prefix = first ? `?` : `&`;
+      if (first) first = false;
+
+      // Return prefixed key with url-encoded values
+      return `${prefix}${key}=${encodeURIComponent(params[key])}`;
     })
     .join("");
 }


### PR DESCRIPTION
Search-query needs to be url-encoded for the fetch-request to be parsed correctly. Considering
special characters...

fix #277
