### PR TITLE
fix: support searching with special characters like & (url-encode search queries)

### DIFF
--- a/utils/createUrlParams.ts
+++ b/utils/createUrlParams.ts
@@ -15,9 +15,9 @@ export function createUrlParams(params: {
       .map((key) => {
         const value = params[key];
         if (Array.isArray(value)) {
-          return value.map((v) => `${key}=${v}`).join("&");
+          return value.map((v) => `${key}=${encodeURIComponent(v)}`).join("&");
         }
-        return `${key}=${value}`;
+        return `${key}=${encodeURIComponent(value)}`;
       })
       .join("&")
   );


### PR DESCRIPTION
Bug #225-resurfaced in PR #278 because we forgot to url-encode the search query.

Fixes #291
