### PR TITLE
fix: include role and time when duplicating a process

### DIFF
--- a/utils/StripGarbage.ts
+++ b/utils/StripGarbage.ts
@@ -9,19 +9,28 @@ import { vsmObject } from "../interfaces/VsmObject";
  * @param childObjects
  * @param choiceGroup
  * @param name
+ * @param role
+ * @param time
+ * @param timeDefinition
  * @param pkObjectType
  */
 export function stripGarbage({
   childObjects,
   choiceGroup,
   name,
+  role,
+  time,
+  timeDefinition,
   vsmObjectType: { pkObjectType },
 }: vsmObject) {
   const newObj = {};
-  if (name) newObj["name"] = name;
-  if (choiceGroup) newObj["choiceGroup"] = choiceGroup;
   if (childObjects?.length > 0)
     newObj["childObjects"] = childObjects.map((o) => stripGarbage(o));
+  if (choiceGroup) newObj["choiceGroup"] = choiceGroup;
+  if (name) newObj["name"] = name;
+  if (role) newObj["role"] = role;
+  if (time) newObj["time"] = time;
+  if (timeDefinition) newObj["timeDefinition"] = timeDefinition;
 
   return {
     ...newObj,


### PR DESCRIPTION
Role and time was not included when duplicating a process.

fix #323
