### PR TITLE
feat: right click and drag around in canvas

### DIFF
--- a/components/canvas/Canvas.tsx
+++ b/components/canvas/Canvas.tsx
@@ -243,7 +243,11 @@ export default function Canvas(): JSX.Element {
         canEdit={userCanEdit}
         selectedObject={selectedObject}
       />
-      <div className={style.canvasWrapper} ref={ref} />
+      <div
+        onContextMenu={(e) => e.preventDefault()} // prevent right click menu
+        className={style.canvasWrapper}
+        ref={ref}
+      />
     </div>
   );
 }


### PR DESCRIPTION
As a user, you may now move around the canvas by holding down either the left or right mouse-button.
The context-menu is disabled and wont be in your way.

close #399
