### PR TITLE
fix: Owner cannot delegate roles from landing page

### DIFF
--- a/components/Card/ProjectCard.tsx
+++ b/components/Card/ProjectCard.tsx
@@ -27,7 +27,7 @@ export function ProjectCard(props: { vsm: vsmProject }): JSX.Element {
   const { accounts } = useMsal();
   const account = useAccount(accounts[0] || {});
   const myAccess = getMyAccess(props.vsm, account);
-  const isAdmin = myAccess === "Admin";
+  const isAdmin = myAccess === "Admin" || myAccess === "Owner";
   const userCanEdit = isAdmin || myAccess == "Contributor";
 
   const handleSettled = () => {


### PR DESCRIPTION
Fixes a bug where an owner of a process were unable to delegate roles from landing page.

Closes #410