### PR TITLE
chore: Remove certificate

### DIFF
--- a/radixconfig-template.yaml
+++ b/radixconfig-template.yaml
@@ -20,9 +20,6 @@ spec:
     - alias: flyt.equinor.com
       environment: prod
       component: web
-    - alias: vsm.equinor.com
-      environment: prod
-      component: web
   components:
     - name: web
       dockerfileName: Dockerfile

--- a/radixconfig.yaml
+++ b/radixconfig.yaml
@@ -20,9 +20,6 @@ spec:
     - alias: flyt.equinor.com
       environment: prod
       component: web
-    - alias: vsm.equinor.com
-      environment: prod
-      component: web
   components:
     - name: web
       dockerfileName: Dockerfile


### PR DESCRIPTION
Removes the certificate for vsm.equinor.com since we no longer use it. We use flyt.equinor.com instead.

Closes #480