### PR TITLE
chore: Use default TypeScript config

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,7 +4,7 @@
     "lib": ["dom", "dom.iterable", "esnext"],
     "allowJs": true,
     "skipLibCheck": true,
-    "strict": false,
+    "strict": true,
     "forceConsistentCasingInFileNames": true,
     "noEmit": true,
     "esModuleInterop": true,
@@ -13,11 +13,11 @@
     "resolveJsonModule": true,
     "isolatedModules": true,
     "jsx": "preserve",
+    "incremental": true,
     "paths": {
-      "mini-signals": ["node_modules/resource-loader/typings/mini-signals.d.ts"]
+      "@/*": ["./*"]
     },
-    "baseUrl": "./",
-    "incremental": true
+    "baseUrl": "./"
   },
   "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx"],
   "exclude": ["node_modules"]


### PR DESCRIPTION
Use the default TypeScript config from a freshly generated Create Next App project. This change makes the TypeScript compiler use strict mode which will detect more type errors in the editor before you build and run the application.

Closes #503