### PR TITLE
fix: info disclaimer session storage

### DIFF
--- a/components/InfoDisclaimer.tsx
+++ b/components/InfoDisclaimer.tsx
@@ -11,12 +11,14 @@ export const InfoDisclaimer = (): JSX.Element => {
   );
 
   useEffect(() => {
-    if (!dontShowAgain) {
+    const dismissedForTab = sessionStorage.getItem("infoDisclaimerDismissed");
+    if (!dontShowAgain && !dismissedForTab) {
       setOpen(true);
     }
   }, [dontShowAgain]);
 
   const handleClose = () => {
+    sessionStorage.setItem("infoDisclaimerDismissed", "true");
     if (dontShowAgain) {
       setDontShowAgain(true);
     }

--- a/components/InfoDisclaimer.tsx
+++ b/components/InfoDisclaimer.tsx
@@ -3,8 +3,10 @@ import { Button, Typography, Scrim, Checkbox } from "@equinor/eds-core-react";
 import useLocalStorage from "../hooks/useLocalStorage";
 import styles from "./InfoDisclaimer.module.scss";
 import colors from "../theme/colors";
+import { useIsAuthenticated } from "@azure/msal-react";
 export const InfoDisclaimer = (): JSX.Element => {
   const [open, setOpen] = useState(false);
+  const isAuthenticated = useIsAuthenticated();
   const [dontShowAgain, setDontShowAgain] = useLocalStorage(
     "infoDisclaimer",
     false
@@ -12,7 +14,7 @@ export const InfoDisclaimer = (): JSX.Element => {
 
   useEffect(() => {
     const dismissedForTab = sessionStorage.getItem("infoDisclaimerDismissed");
-    if (!dontShowAgain && !dismissedForTab) {
+    if (isAuthenticated && !dontShowAgain && !dismissedForTab) {
       setOpen(true);
     }
   }, [dontShowAgain]);


### PR DESCRIPTION
ticket - https://github.com/equinor/flyt/issues/1124

Fixes implemented for Information Disclaimer popup:
1.Updated disclaimer popup behavior to prevent it from reappearing within the same browser tab after the user clicks Continue.
2.Once Continue is clicked, the disclaimer remains hidden for all subsequent page navigations.
3.The disclaimer will be displayed again only when the application is opened in a new browser tab, unless the user has selected "Do not show this message again".
